### PR TITLE
improve channel utilization

### DIFF
--- a/src/discovery/event.rs
+++ b/src/discovery/event.rs
@@ -1,39 +1,7 @@
-use std::thread;
-use std::sync::mpsc;
-
-use crate::discovery::listener::DiscoveryListener;
 use crate::player::{Player};
 
 #[derive(Debug)]
 pub enum Event {
     Annoncement(Player),
     Error(String),
-}
-
-pub struct Events {
-    rx: mpsc::Receiver<Event>,
-    handler: thread::JoinHandle<()>,
-}
-
-impl Events {
-    pub fn new() -> Self {
-        let (tx, rx) = mpsc::channel();
-
-        let player_discovery_channel = {
-            let discover_listener = DiscoveryListener::new();
-            let tx = tx.clone();
-            thread::spawn(move || loop {
-                tx.send(discover_listener.receive()).unwrap()
-            })
-        };
-
-        Self {
-            rx: rx,
-            handler: player_discovery_channel,
-        }
-    }
-
-    pub fn next(&self) -> Result<Event, mpsc::RecvError> {
-        self.rx.recv()
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,10 @@ fn main() -> Result<(), failure::Error> {
             {
                 let events = app.players.iter().map(|player| {
                     Text::styled(
-                        format!("{}: {}", player.number, player.model),
+                        format!("{}: {} ({})",
+                            player.number,
+                            player.model,
+                            player.address.ip()),
                         Style::default().fg(Color::White)
                     )
                 });

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,6 @@ use tui::Terminal;
 
 use crate::util::event::{Event, Events};
 use crate::discovery::event::{
-    Events as DiscoveryEvents,
     Event as DiscoveryEvent,
 };
 use crate::player::{PlayerCollection};
@@ -45,7 +44,6 @@ fn main() -> Result<(), failure::Error> {
     terminal.hide_cursor()?;
 
     let events = Events::new();
-    let discovery_events = DiscoveryEvents::new();
 
     let mut app = App::new();
 
@@ -79,14 +77,13 @@ fn main() -> Result<(), failure::Error> {
             }
             Event::Tick => {
                 app.update();
-            }
-        };
-
-        match discovery_events.next()? {
-            DiscoveryEvent::Annoncement(player) => {
-                app.players.add_or_update(player);
             },
-            DiscoveryEvent::Error(_) => (),
+            Event::Discovery(evnt) => {
+                match evnt {
+                    DiscoveryEvent::Annoncement(player) => app.players.add_or_update(player),
+                    _ => (),
+                }
+            }
         };
     }
 

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -1,5 +1,4 @@
 use std::net::{SocketAddr};
-use std::error::{Error};
 
 #[derive(Debug, Clone)]
 pub struct Player {

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -42,13 +42,15 @@ impl PlayerCollection {
         self.players.push(player);
     }
 
-    pub fn get(&self, address: &SocketAddr) -> Option<&Player> {
-        self.players.iter().find(|&p| p.address == *address)
+    pub fn get_mut(&mut self, address: &SocketAddr) -> Option<&mut Player> {
+        self.players.iter_mut().find(|p| p.address == *address)
     }
 
     pub fn add_or_update(&mut self, player: Player) {
-        match self.get(&player.address) {
-            Some(_) => {},
+        match self.get_mut(&player.address) {
+            Some(mut p) => {
+                p.number = player.number;
+            },
             None => {
                 self.push(player);
             },


### PR DESCRIPTION
This change will improve the event_loop in this program.
The most concerning issue was that the DiscoveryListener's channel blocked the whole program from receiving events. An example of an event was when a user pressed Q to quit the program.

With this in place it's much more stable.

A future improvement will be to enhance the ergonomics in constructing these events.