### PR TITLE
RPC: Mount procedure

### DIFF
--- a/docs/rekordbox/README.md
+++ b/docs/rekordbox/README.md
@@ -1,0 +1,2 @@
+## PDF File describing Rekordbox XML layout!
+http://www.prodjnet.com/rekordbox/support/pdf/xml_format_list.pdf

--- a/docs/rekordbox/portmapping.md
+++ b/docs/rekordbox/portmapping.md
@@ -6,7 +6,7 @@
 |-------------|--------------|-------------|-------------|-------------|-------------|
 | XID         | Message type | RPC Ver.    | Prog.       | Prog. Ver.  | Procedure   |
 |-------------|--------------|-------------|-------------|-------------|-------------|
-| 00:00:00:01 | 00:00:00:00  | 00:00:00:02 | 00:01:86:a0 | 00:00:00:02 | 00:00:00:03 | 
+| 00:00:00:01 | 00:00:00:00  | 00:00:00:02 | 00:01:86:a0 | 00:00:00:02 | 00:00:00:03 |
 
 |                                           Credentials                                            |         Verifier          |
 |-------------|-------------|-------------|--------------+-------------+-------------+-------------+-------------+-------------|
@@ -39,7 +39,7 @@
 For the communication to work the server should allocate SocketAddr
 and in the portmap reply that port address should be transmitted.
 
-Eg: 
+Eg:
 
 PORTMAP Reply: port 42039
 EXPORT Call dstport 42039
@@ -53,13 +53,43 @@ EXPORT Call dstport 42039
 |-------------|--------------|-------------|-------------|-------------|-------------|
 | XID         | Message type | RPC Ver.    | Prog.       | Prog. Ver.  | Procedure   |
 |-------------|--------------|-------------|-------------|-------------|-------------|
-| 00:00:00:02 | 00:00:00:00  | 00:00:00:02 | 00:01:86:a5 | 00:00:00:01 | 00:00:00:05 | 
+| 00:00:00:02 | 00:00:00:00  | 00:00:00:02 | 00:01:86:a5 | 00:00:00:01 | 00:00:00:05 |
 
 |                                           Credentials                                            |         Verifier          |
 |-------------|-------------|-------------|--------------|-----------------------------------------|-------------|-------------|
 | Flavor      | Length      | Stamp       | Machine name | UID         | GID         | AUX GID     | Flavor      | Length      |
 |-------------|-------------|-------------|--------------|-------------|-------------|-------------|-------------|-------------|
 | 00:00:00:01 | 00:00:00:14 | 99:22:e1:12 | 00:00:00:00  | 00:00:00:00 | 00:00:00:00 | 00:00:00:00 | 00:00:00:00 | 00:00:00:00 |
+
+
+Frame 566: 102 bytes on wire (816 bits), 102 bytes captured (816 bits) on interface 0
+Ethernet II, Src: PioneerD_04:1d:e6 (c8:3d:fc:04:1d:e6), Dst: Apple_35:bc:4d (ac:87:a3:35:bc:4d)
+Internet Protocol Version 4, Src: 169.254.29.230, Dst: 169.254.37.116
+User Datagram Protocol, Src Port: 4056, Dst Port: 42039
+Remote Procedure Call, Type:Call XID:0x00000002
+    XID: 0x00000002 (2)
+    Message Type: Call (0)
+    RPC Version: 2
+    Program: MOUNT (100005)
+    Program Version: 1
+    Procedure: EXPORT (5)
+    [The reply to this request is in frame 568]
+    Credentials
+        Flavor: AUTH_UNIX (1)
+        Length: 20
+        Stamp: 0x9922e112
+        Machine Name: <EMPTY>
+            length: 0
+            contents: <EMPTY>
+        UID: 0
+        GID: 0
+        Auxiliary GIDs (0)
+    Verifier
+        Flavor: AUTH_NULL (0)
+        Length: 0
+Mount Service
+    [Program Version: 1]
+    [V1 Procedure: EXPORT (5)]
 
 =====
 
@@ -71,7 +101,7 @@ EXPORT Call dstport 42039
 |-------------+--------------+-------------+-------------+-------------+--------------|
 | XID         | Message type | Reply state | Flavor      | Length      | Accept State |
 |-------------+--------------+-------------+-------------+-------------+--------------|
-| 00:00:00:02 | 00:00:00:01  | 00:00:00:00 | 00:00:00:00 | 00:00:00:00 | 00:00:00:00  | 
+| 00:00:00:02 | 00:00:00:01  | 00:00:00:00 | 00:00:00:00 | 00:00:00:00 | 00:00:00:00  |
 
 | Mount service |
 |---------------|

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod rekordbox;
 mod utils;
 mod component;
+mod rpc;
 
 extern crate rand;
 extern crate pnet;

--- a/src/rekordbox/mod.rs
+++ b/src/rekordbox/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 // TODO: Make private
 pub const SOFTWARE_IDENTIFICATION: [u8; 10] = [
     0x51,0x73,0x70,0x74,0x31,0x57,0x6d,0x4a,0x4f,0x4c
@@ -11,9 +13,9 @@ pub const APPLICATION_NAME: [u8; 20] = [
 pub mod client;
 pub mod event;
 pub mod player;
+pub mod rpc_socket_pool;
+pub mod util;
 
 // Internal mods
-mod rpc;
 mod message;
-mod util;
-mod rpc_socket_pool;
+mod rpc;

--- a/src/rekordbox/rpc.rs
+++ b/src/rekordbox/rpc.rs
@@ -1,386 +1,66 @@
-extern crate byteorder;
+use std::collections::HashMap;
+use crate::rpc::{RPCCall, RPCReply, RPC, Mount, self};
 
-use byteorder::{WriteBytesExt, BigEndian};
-use std::io::ErrorKind;
-use std::io;
-use std::net::{UdpSocket, SocketAddr};
-use std::ops::RangeInclusive;
-use std::sync::{Arc, RwLock, Mutex};
-use std::thread::{self, JoinHandle};
-use std::time::Duration;
+type Callback = fn(RPC) -> Option<RPCReply>;
 
-use super::util::clone_into_array;
-use super::client::ClientState;
-use super::rpc_socket_pool::{Pool, PooledPort};
-
-type RPCPropertyValue = [u8; 4];
-
-#[derive(Debug, PartialEq)]
-pub enum RPC {
-    Portmap(RPCCall, Portmap),
+pub struct EventHandler {
+    callbacks: HashMap<String, Callback>,
+    // mpsc
 }
 
-#[derive(Debug, PartialEq)]
-pub enum Portmap {
-    Getport(Getport),
+impl EventHandler {
+    pub fn new() -> Self {
+        let mut handler = EventHandler {
+            callbacks: HashMap::new(),
+        };
+
+        handler.add_callback("Export".to_string(), rpc_method_export);
+        handler.add_callback("MNT".to_string(), rpc_method_mnt);
+
+        handler
+    }
+
+    fn add_callback(&mut self, name: String, func: Callback) {
+        self.callbacks.insert(name, func);
+    }
 }
 
-#[derive(Debug, PartialEq)]
-pub enum Getport {
-    Mount(Mount),
-    NFS,
+fn rpc_method_export(rpc_program: RPC) -> Option<RPCReply> {
+    eprintln!("RPC_METHOD_EXPORT: {:?}", rpc_program);
+    Some(RPCReply::Export(Mount::Export {}))
 }
 
-enum RPCProcedure {
-    Getport,
-    Unknown,
+fn rpc_method_mnt(rpc_program: RPC) -> Option<RPCReply> {
+    Some(RPCReply::Mnt(Mount::Mnt {}))
 }
 
-enum RPCProgram {
-    Portmap,
-    Unknown,
-}
-
-
-
-pub struct RPCServer {
-    state: Arc<RwLock<ClientState>>,
-    port_pool: Pool,
-}
-impl RPCServer {
-    pub fn new(state: Arc<RwLock<ClientState>>) -> Self {
-        Self {
-            state: state,
-            port_pool: Pool::new(4096..=4104).unwrap(),
+impl rpc::server::EventHandler for EventHandler {
+    fn on_event(&self, name: &str, rpc_program: RPC) -> Option<RPCReply> {
+        if self.callbacks.contains_key(name) == true {
+            return self.callbacks[name](rpc_program)
         }
+        None
     }
-
-    pub fn run(&self) {
-        let port_pool = self.port_pool.clone();
-        thread::spawn(move || {
-            // TODO: read address from shared state
-            let mut socket = UdpSocket::bind(("0.0.0.0", 50111)).unwrap();
-            socket.set_nonblocking(true).unwrap();
-
-            loop {
-                let mut buffer = [0u8; 512];
-                match socket.recv_from(&mut buffer) {
-                    Ok((_number_of_bytes, source)) => {
-                        match parse_rpc_message(&buffer) {
-                            Ok(event) => {
-                                match event {
-                                    RPC::Portmap(rpc_call, _portmap) => {
-                                        Self::create_response_handler(
-                                            rpc_call,
-                                            &socket,
-                                            &source,
-                                            port_pool.get().unwrap()
-                                        );
-                                    }
-                                }
-                            },
-                            Err(_) => {},
-                        }
-                    },
-                    Err(ref err) if err.kind() != ErrorKind::WouldBlock => {
-                        println!("Something went wrong: {}", err)
-                    },
-                    _ => {},
-                }
-                thread::sleep(Duration::from_millis(300));
-            }
-        });
-    }
-
-    // This method should have access to adding events to the event loop
-    pub fn create_response_handler(
-        call: RPCCall,
-        socket: &UdpSocket,
-        receiver: &SocketAddr,
-        reply_port: PooledPort, 
-    ) {
-        eprintln!("{:?}", reply_port.get_port());
-        let allocated_socket = UdpSocket::bind(("0.0.0.0", reply_port.get_port())).unwrap();
-
-        let data: Vec<u8> = vec![
-            call.xid.to_vec(),
-            [0x00, 0x00, 0x00, 0x01].to_vec(),
-            [0u8; 4].to_vec(),
-            [0u8; 4].to_vec(),
-            [0u8; 4].to_vec(),
-            [0u8; 4].to_vec(),
-            vec![0x00, 0x00], convert_u16_to_two_u8s_be(reply_port.get_port()),
-        ].into_iter().flatten().collect();
-
-        match socket.send_to(data.as_ref(), receiver) {
-            Ok(nob) => eprintln!("{:?}", nob),
-            Err(error) => eprintln!("{:?}", error),
-        }
-
-        thread::spawn(move || {
-            allocated_socket.set_read_timeout(Some(Duration::from_millis(2000))).unwrap();
-            let mut buffer = [0u8; 512];
-            match allocated_socket.recv(&mut buffer) {
-                Ok(number_of_bytes) => {
-                    eprintln!("Got RPC data: {:?}", buffer[..number_of_bytes].as_ref());
-                },
-                Err(error) => eprintln!("{:?}", error.to_string()),
-            }
-        });
-    }
-}
-
-#[derive(Debug, PartialEq)]
-pub struct RPCCall {
-    xid: RPCPropertyValue,
-    message_type: RPCPropertyValue,
-    rpc_version: RPCPropertyValue,
-    program: RPCPropertyValue,
-    program_version: RPCPropertyValue,
-    procedure: RPCPropertyValue,
-    credentials: RPCCredentials,
-    verifier: RPCVerifier,
-}
-
-impl RPCCall {
-    fn get_program(&self) -> RPCProgram {
-        if self.program == [0x00, 0x01, 0x86, 0xa0] {
-            RPCProgram::Portmap
-        } else {
-            RPCProgram::Unknown
-        }
-    }
-
-    fn get_procedure(&self) -> RPCProcedure {
-        if self.procedure == [0x00, 0x00, 0x00, 0x03] {
-            RPCProcedure::Getport
-        } else {
-            RPCProcedure::Unknown
-        }
-    }
-}
-
-#[derive(Debug, PartialEq)]
-struct RPCVerifier {
-    flavor: RPCPropertyValue,
-    length: RPCPropertyValue,
-}
-
-#[derive(Debug, PartialEq)]
-struct RPCCredentials {
-    flavor: RPCPropertyValue,
-    length: RPCPropertyValue,
-    stamp: RPCPropertyValue,
-    machine_name: RPCPropertyValue,
-    uid: RPCPropertyValue,
-    gid: RPCPropertyValue,
-    aux_gid: RPCPropertyValue,
-}
-
-#[derive(Debug, PartialEq)]
-struct Mount {
-    program: RPCPropertyValue,
-    version: RPCPropertyValue,
-    protocol: RPCPropertyValue,
-    port: RPCPropertyValue,
-}
-
-#[derive(Debug, PartialEq)]
-enum RPCMessageType {
-    Call,
-    Reply,
-    Unknown,
-}
-
-const RPC_MESSAGE_TYPE_POSITION: RangeInclusive<usize> = 4..=7;
-
-fn get_message_type(message: &[u8]) -> RPCMessageType {
-    if message[RPC_MESSAGE_TYPE_POSITION] == [0x00, 0x00, 0x00, 0x00] {
-        RPCMessageType::Call
-    } else if message[RPC_MESSAGE_TYPE_POSITION] == [0x00, 0x00, 0x00, 0x01] {
-        RPCMessageType::Reply
-    } else {
-        RPCMessageType::Unknown
-    }
-}
-
-fn parse_rpc_call(message: &[u8]) -> RPCCall {
-    RPCCall {
-        xid: clone_into_array(&message[0..=3]),
-        message_type: clone_into_array(&message[RPC_MESSAGE_TYPE_POSITION]),
-        rpc_version: clone_into_array(&message[8..=11]),
-        program: clone_into_array(&message[12..=15]),
-        program_version: clone_into_array(&message[16..=19]),
-        procedure: clone_into_array(&message[20..=23]),
-        credentials: RPCCredentials {
-            flavor: clone_into_array(&message[24..=27]),
-            length: clone_into_array(&message[28..=31]),
-            stamp: clone_into_array(&message[32..=35]),
-            machine_name: clone_into_array(&message[36..=39]),
-            uid: clone_into_array(&message[40..=43]),
-            gid: clone_into_array(&message[44..=47]),
-            aux_gid: clone_into_array(&message[48..=51]),
-        },
-        verifier: RPCVerifier {
-            flavor: clone_into_array(&message[52..=55]),
-            length: clone_into_array(&message[56..=59]),
-        }
-    }
-}
-
-fn parse_rpc_program(call: RPCCall, message: &[u8]) -> Result<RPC, &'static str> {
-    match (call.get_program(), call.get_procedure()) {
-        (RPCProgram::Portmap, RPCProcedure::Getport) => {
-            Ok(RPC::Portmap(call, Portmap::Getport(
-                Getport::Mount(Mount {
-                    program: clone_into_array(&message[60..=63]),
-                    version: clone_into_array(&message[64..=67]),
-                    protocol: clone_into_array(&message[68..=71]),
-                    port: clone_into_array(&message[72..=75]),
-                })
-            )) )
-        },
-        (_, _) => Err("Unknown rpc program"),
-    }
-}
-
-// parse call (message type)
-pub fn parse_rpc_message(message: &[u8]) -> Result<RPC, &'static str> {
-    match get_message_type(message.as_ref()) {
-        RPCMessageType::Call => {
-            let call = parse_rpc_call(message.as_ref());
-            parse_rpc_program(call, message.as_ref())
-        },
-        RPCMessageType::Reply => {
-            Err("err")
-        },
-        RPCMessageType::Unknown => {
-            Err("Err")
-        },
-    }
-}
-
-fn convert_u16_to_two_u8s_be(integer: u16) -> Vec<u8> {
-    let mut res = vec![];
-    res.write_u16::<BigEndian>(integer).unwrap();
-    res
 }
 
 #[cfg(test)]
 mod test {
-    use crate::rekordbox::rpc::{
-        RPCCall,
-        RPCVerifier,
-        RPCCredentials,
-        RPC,
-        RPCMessageType,
-        Getport,
-        Portmap,
-        Mount,
-        parse_rpc_message,
-        get_message_type,
-    };
+    use super::{EventHandler, RPCReply};
+    use crate::rpc::{RPC, RPCCall, Mount};
+    use crate::rpc::server::EventHandler as RPCEventHandler;
+    use crate::rpc::factories::generate_rpc_mount_procedure;
 
-    #[test]
-    fn it_can_match_message_type() {
-        assert_eq!(get_message_type(&[
-            0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00]
-        ), RPCMessageType::Call);
-
-        assert_eq!(get_message_type(&[
-            0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x01]
-        ), RPCMessageType::Reply);
+    fn test_method(rpc: RPC) -> Option<RPCReply> {
+        Some(RPCReply::Export(Mount::Export {}))
     }
 
     #[test]
-    fn it_can_parse_rpc_message() {
-        let message: Vec<u8> = vec![
+    fn it_will_call_callback() {
+        let mut handler = EventHandler::new();
+        let rpc_program = generate_rpc_mount_procedure();
 
-            // ============= RPC START =============
-
-            // XID
-            0x00,0x00,0x00,0x01,
-            // Message type
-            0x00,0x00,0x00,0x00,
-            // RPC Ver.
-            0x00,0x00,0x00,0x02,
-            // Program
-            0x00,0x01,0x86,0xa0,
-            // Program version
-            0x00,0x00,0x00,0x02,
-            // Procedure
-            0x00,0x00,0x00,0x03,
-
-            // Credentials
-
-            // Flavor
-            0x00,0x00,0x00,0x01,
-            // Length
-            0x00,0x00,0x00,0x14,
-            // Stamp
-            0x96,0x7b,0x87,0x03,
-            // Machine name
-            0x00,0x00,0x00,0x00,
-            // UID
-            0x00,0x00,0x00,0x00,
-            // GID
-            0x00,0x00,0x00,0x00,
-            // AUX GID
-            0x00,0x00,0x00,0x00,
-
-            // Verifier
-
-            // Flavor
-            0x00,0x00,0x00,0x00,
-            // Length
-            0x00,0x00,0x00,0x00,
-
-            // ========== RPC END ============
-
-            // PORTMAP
-
-            // Program
-            0x00,0x01,0x86,0xa5,
-            // Version
-            0x00,0x00,0x00,0x01,
-            // Protocol
-            0x00,0x00,0x00,0x11,
-            // Port
-            0x00,0x00,0x00,0x00,
-        ];
-
-        assert_eq!(parse_rpc_message(message.as_ref()), Ok(
-            RPC::Portmap(
-                RPCCall {
-                    xid: [0x00, 0x00, 0x00, 0x01],
-                    message_type: [0x00,0x00,0x00,0x00],
-                    rpc_version: [0x00,0x00,0x00,0x02],
-                    program: [0x00,0x01,0x86,0xa0],
-                    program_version: [0x00,0x00,0x00,0x02],
-                    procedure: [0x00,0x00,0x00,0x03],
-                    credentials: RPCCredentials {
-                        flavor: [0x00,0x00,0x00,0x01],
-                        length: [0x00,0x00,0x00,0x14],
-                        stamp: [0x96,0x7b,0x87,0x03],
-                        machine_name: [0x00,0x00,0x00,0x00],
-                        uid: [0x00,0x00,0x00,0x00],
-                        gid: [0x00,0x00,0x00,0x00],
-                        aux_gid: [0x00,0x00,0x00,0x00],
-                    },
-                    verifier: RPCVerifier {
-                        flavor: [0x00,0x00,0x00,0x00],
-                        length: [0x00,0x00,0x00,0x00],
-                    }
-                },
-                Portmap::Getport(Getport::Mount(Mount {
-                    program: [0x00,0x01,0x86,0xa5],
-                    version: [0x00,0x00,0x00,0x01],
-                    protocol: [0x00,0x00,0x00,0x11],
-                    port: [0x00,0x00,0x00,0x00],
-                }))
-            )
-        ));
+        handler.add_callback("Testmethod".to_string(), test_method);
+        assert_eq!(handler.on_event("Testmethod", rpc_program),
+            Some(RPCReply::Export(Mount::Export {})));
     }
 }

--- a/src/rekordbox/rpc_socket_pool.rs
+++ b/src/rekordbox/rpc_socket_pool.rs
@@ -1,10 +1,7 @@
 extern crate parking_lot;
 
-use std::error;
-use std::fmt;
-use std::ops::{Deref, DerefMut};
-use std::sync::{Arc, Weak};
-use std::time::{Duration, Instant};
+use std::ops::{Deref};
+use std::sync::{Arc};
 use parking_lot::{Mutex, MutexGuard};
 
 #[derive(Debug)]

--- a/src/rpc/factories.rs
+++ b/src/rpc/factories.rs
@@ -1,0 +1,26 @@
+use super::RPC;
+
+fn set_rpc_version_2(buffer: &mut [u8]) {
+    buffer[11] = 0x02;
+}
+
+pub fn generate_rpc_mount_procedure() -> RPC {
+    let mut buffer = [0x00; 76];
+    set_rpc_version_2(&mut buffer);
+    buffer[13] = 0x01;
+    buffer[14] = 0x86;
+    buffer[15] = 0xa0;
+    buffer[23] = 0x03;
+
+    buffer[60] = 0x00;
+    buffer[61] = 0x01;
+    buffer[62] = 0x86;
+    buffer[63] = 0xa5;
+
+    buffer[72] = 0x00;
+    buffer[73] = 0x01;
+    buffer[74] = 0xa4;
+    buffer[75] = 0x37;
+
+    RPC::unmarshall(&buffer)
+}

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -1,0 +1,292 @@
+#![allow(dead_code)]
+#![allow(non_snake_case)]
+
+use std::ops::RangeInclusive;
+use crate::rekordbox::util::clone_into_array;
+use std::collections::HashMap;
+
+pub mod server;
+#[cfg(test)]
+mod test;
+#[cfg(test)]
+pub mod factories;
+
+type RPCPropertyValue = [u8; 4];
+
+pub mod NFS {
+    #[derive(Debug, PartialEq)]
+    pub enum Procedure {
+        Lookup(Lookup),
+        Getattr(Getattr),
+        Read(Read),
+    }
+
+    #[derive(Debug, PartialEq)]
+    pub struct Lookup;
+    #[derive(Debug, PartialEq)]
+    pub struct Getattr;
+    #[derive(Debug, PartialEq)]
+    pub struct Read;
+}
+
+pub mod Portmap {
+    use super::RPCPropertyValue;
+    use crate::rekordbox::util::clone_into_array;
+
+    #[derive(Debug, PartialEq)]
+    pub enum Program {
+        Getport(Procedure)
+    }
+
+    #[derive(Debug, PartialEq)]
+    pub enum Procedure {
+        Mount(Portmap),
+        NFS(Portmap),
+        Unknown,
+    }
+
+    fn unpack(buffer: &[u8]) -> Portmap {
+        Portmap {
+            program: clone_into_array(&buffer[..=3]),
+            version: clone_into_array(&buffer[4..=7]),
+            protocol: clone_into_array(&buffer[8..=11]),
+            port: clone_into_array(&buffer[12..=15]),
+        }
+    }
+
+    pub fn unmarshall(message: &[u8]) -> Program {
+        Program::Getport(match &message[3] {
+            0xa5 => Procedure::Mount(unpack(&message)),
+            0xa3 => Procedure::NFS(unpack(&message)),
+            _ => Procedure::Unknown,
+        })
+    }
+
+    #[derive(Debug, PartialEq)]
+    pub struct Portmap {
+        pub program: RPCPropertyValue,
+        pub version: RPCPropertyValue,
+        pub protocol: RPCPropertyValue,
+        pub port: RPCPropertyValue,
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::{Procedure, unmarshall, Program};
+
+        #[test]
+        fn it_can_unmarshal_procedures() {
+            let mut buffer = [0x00; 16];
+            buffer[0] = 0x00;
+            buffer[1] = 0x01;
+            buffer[2] = 0x86;
+            buffer[3] = 0xa5;
+
+            assert_eq!(match unmarshall(&buffer) {
+                Program::Getport(program) => {
+                    match program {
+                        Procedure::Mount(_portmap) => true,
+                        _ => false,
+                    }
+                }
+            }, true);
+
+            buffer[3] = 0xa3;
+            assert_eq!(match unmarshall(&buffer) {
+                Program::Getport(program) => {
+                    match program {
+                        Procedure::NFS(_portmap) => true,
+                        _ => false,
+                    }
+                }
+            }, true);
+        }
+    }
+}
+
+pub mod Mount {
+    use super::{RPCProcedure, RPCCall};
+
+    #[derive(Debug, PartialEq)]
+    pub enum Procedure {
+        Export(Export),
+        Mnt(Mnt),
+        Unknown,
+    }
+
+    pub fn unmarshall(rpc_call: &RPCCall, _buffer: &[u8]) -> Procedure {
+        match rpc_call.procedure {
+            RPCProcedure::Export => Procedure::Export(Export {}),
+            RPCProcedure::Mnt => Procedure::Mnt(Mnt {}),
+            _ => Procedure::Unknown,
+        }
+    }
+
+    #[derive(Debug, PartialEq)]
+    pub struct Export;
+    #[derive(Debug, PartialEq)]
+    pub struct Mnt;
+}
+
+#[derive(Debug, PartialEq)]
+pub enum RPC {
+    Portmap(RPCCall, Portmap::Program),
+    NFS(RPCCall, NFS::Procedure),
+    Mount(RPCCall, Mount::Procedure),
+    Error(String),
+}
+
+#[derive(Debug, PartialEq)]
+enum RPCProgram {
+    NFS,
+    Mount,
+    Portmap,
+    Unknown,
+}
+
+#[derive(Debug, PartialEq)]
+enum RPCProcedure {
+    Export,
+    Getport,
+    Mnt,
+    Lookup,
+    Getattr,
+    Read,
+    Unknown,
+}
+
+impl RPC {
+    fn unmarshall_message(buffer: &[u8]) -> Result<(RPCCall, &[u8]), &'static str> {
+        if buffer[RPC_MESSAGE_TYPE_POSITION] != [0x00, 0x00, 0x00, 0x00] {
+            return Err("Server received a reply");
+        }
+
+        if buffer[8..=11] != [0x00, 0x00, 0x00, 0x02] {
+            return Err("Only RPC Version 2 is supported");
+        }
+
+        let (program, procedure) = RPC::match_program(&buffer[12..=23]);
+        let call = RPCCall {
+            xid: clone_into_array(&buffer[0..=3]),
+            message_type: clone_into_array(&buffer[RPC_MESSAGE_TYPE_POSITION]),
+            rpc_version: clone_into_array(&buffer[8..=11]),
+            program: program,
+            program_version: clone_into_array(&buffer[16..=19]),
+            procedure: procedure,
+            credentials: RPCCredentials {
+                flavor: clone_into_array(&buffer[24..=27]),
+                length: clone_into_array(&buffer[28..=31]),
+                stamp: clone_into_array(&buffer[32..=35]),
+                machine_name: clone_into_array(&buffer[36..=39]),
+                uid: clone_into_array(&buffer[40..=43]),
+                gid: clone_into_array(&buffer[44..=47]),
+                aux_gid: clone_into_array(&buffer[48..=51]),
+            },
+            verifier: RPCVerifier {
+                flavor: clone_into_array(&buffer[52..=55]),
+                length: clone_into_array(&buffer[56..=59]),
+            }
+        };
+
+        Ok((call, &buffer[60..]))
+    }
+
+    // This buffer should not contain RPC Call body
+    fn unmarshall_procedure(call: RPCCall, buffer: &[u8]) -> RPC {
+        match call.program {
+            RPCProgram::Portmap => {
+                RPC::Portmap(call, Portmap::unmarshall(&buffer))
+            },
+            RPCProgram::Mount => {
+                let procedure = Mount::unmarshall(&call, &buffer);
+                RPC::Mount(call, procedure)
+            },
+            _ => RPC::Error(String::from("Unhandled type")),
+            //RPCProgram::Mount => {},
+            //RPCProgram::NFS => {},
+            //RPCProgram::Unknown => {},
+        }
+    }
+
+    pub fn unmarshall(buffer: &[u8]) -> RPC {
+        match Self::unmarshall_message(&buffer) {
+            Ok((call, procedure_buffer)) => Self::unmarshall_procedure(call, &procedure_buffer),
+            Err(err) => RPC::Error(err.to_string()),
+        }
+    }
+
+    fn match_program(buffer: &[u8]) -> (RPCProgram, RPCProcedure) {
+        let program = &buffer[..=3];
+        let _program_version = &buffer[4..=7];
+        let procedure = &buffer[8..];
+
+        if program == &[0x00, 0x01, 0x86, 0xa0] {
+            (RPCProgram::Portmap, match procedure {
+                &[0x00, 0x00, 0x00, 0x03] => RPCProcedure::Getport,
+                _ => RPCProcedure::Unknown,
+            })
+        }
+        else if program == &[0x00, 0x01, 0x86, 0xa3] {
+            (RPCProgram::NFS, match procedure {
+                &[0x00, 0x00, 0x00, 0x04] => RPCProcedure::Lookup,
+                &[0x00, 0x00, 0x00, 0x01] => RPCProcedure::Getattr,
+                &[0x00, 0x00, 0x00, 0x06] => RPCProcedure::Read,
+                _ => RPCProcedure::Unknown,
+            })
+        }
+        else if program == &[0x00, 0x01, 0x86, 0xa5] {
+            (RPCProgram::Mount, match procedure {
+                &[0x00, 0x00, 0x00, 0x01] => RPCProcedure::Mnt,
+                &[0x00, 0x00, 0x00, 0x05] => RPCProcedure::Export,
+                _ => RPCProcedure::Unknown,
+            })
+        } else {
+            (RPCProgram::Unknown, RPCProcedure::Unknown)
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct RPCCall {
+    xid: RPCPropertyValue,
+    message_type: RPCPropertyValue,
+    rpc_version: RPCPropertyValue,
+    program: RPCProgram,
+    program_version: RPCPropertyValue,
+    procedure: RPCProcedure,
+    credentials: RPCCredentials,
+    verifier: RPCVerifier,
+}
+
+/// RPC data types
+
+#[derive(Debug, PartialEq)]
+struct RPCVerifier {
+    flavor: RPCPropertyValue,
+    length: RPCPropertyValue,
+}
+
+#[derive(Debug, PartialEq)]
+struct RPCCredentials {
+    flavor: RPCPropertyValue,
+    length: RPCPropertyValue,
+    stamp: RPCPropertyValue,
+    machine_name: RPCPropertyValue,
+    uid: RPCPropertyValue,
+    gid: RPCPropertyValue,
+    aux_gid: RPCPropertyValue,
+}
+
+#[derive(Debug, PartialEq)]
+enum RPCMessageType {
+    Call,
+    Reply,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum RPCReply {
+    Export(Mount::Export),
+    Mnt(Mount::Mnt),
+}
+
+const RPC_MESSAGE_TYPE_POSITION: RangeInclusive<usize> = 4..=7;

--- a/src/rpc/server.rs
+++ b/src/rpc/server.rs
@@ -1,0 +1,127 @@
+extern crate byteorder;
+
+use byteorder::{WriteBytesExt, BigEndian};
+use std::net::{UdpSocket, SocketAddr};
+use crate::rekordbox::rpc_socket_pool::Pool;
+use super::{RPC, Portmap, RPCCall, RPCReply, Mount};
+use std::io::Error;
+use std::time::Duration;
+use std::thread;
+use std::sync::Arc;
+
+pub struct RPCServer {
+    port_pool: Pool,
+    socket: UdpSocket,
+}
+
+pub trait EventHandler: Send + Sync + 'static {
+    fn on_event(&self, name: &str, rpc_program: RPC) -> Option<RPCReply>;
+}
+
+impl RPCServer {
+    pub fn new() -> Self {
+        Self {
+            port_pool: Pool::new(4096..=4104).unwrap(),
+            socket: UdpSocket::bind(("0.0.0.0", 50111)).unwrap(),
+        }
+    }
+
+    pub fn run<T: EventHandler>(&self, handler: T) {
+        let handler_ref = Arc::new(handler);
+
+        loop {
+            // We should only receive portmapping events here.
+            // This should be routed to the correct module.
+            match self.recv() {
+                Ok((rpc_call, source)) => self.portmap_router(rpc_call, source, handler_ref.clone()),
+                Err(err) => eprintln!("{:?}", err.to_string()),
+            }
+
+            thread::sleep(Duration::from_millis(300));
+        }
+    }
+
+    fn portmap_router<T: EventHandler>(
+        &self,
+        call: RPC,
+        receiver: SocketAddr,
+        handler: Arc<T>,
+    ) {
+        match call {
+            RPC::Portmap(rpc_call, Portmap::Program::Getport(program)) => {
+                match program {
+                    Portmap::Procedure::Mount(portmap) => {
+                        self.create_response_handler(rpc_call, receiver, handler);
+                    },
+                    Portmap::Procedure::NFS(portmap) => {
+                        eprintln!("Portmapping NFS: {:?}", portmap);
+                    },
+                    Portmap::Procedure::Unknown => {},
+                }
+            },
+            _ => {
+                eprintln!("{:?}", "portmap event");
+            }
+        }
+    }
+
+    fn recv(&self) -> Result<(RPC, SocketAddr), Error> {
+        let mut buffer = [0u8; 512];
+        match self.socket.recv_from(&mut buffer) {
+            Ok((number_of_bytes, source)) => {
+                Ok((RPC::unmarshall(&buffer[..number_of_bytes]), source))
+            },
+            Err(err) => Err(err),
+        }
+    }
+
+    pub fn create_response_handler<T: EventHandler>(
+        &self,
+        call: RPCCall,
+        receiver: SocketAddr,
+        handler: Arc<T>,
+    ) {
+        let reply_port = self.port_pool.get().unwrap();
+        let allocated_socket = UdpSocket::bind(("0.0.0.0", reply_port.get_port())).unwrap();
+        let data: Vec<u8> = vec![
+            call.xid.to_vec(),
+            [0x00, 0x00, 0x00, 0x01].to_vec(),
+            [0u8; 4].to_vec(),
+            [0u8; 4].to_vec(),
+            [0u8; 4].to_vec(),
+            [0u8; 4].to_vec(),
+            vec![0x00, 0x00], convert_u16_to_two_u8s_be(reply_port.get_port()),
+        ].into_iter().flatten().collect();
+
+        match self.socket.send_to(data.as_ref(), receiver) {
+            Ok(nob) => eprintln!("{:?}", nob),
+            Err(error) => eprintln!("{:?}", error),
+        }
+
+        let _procedure_callback_handler = {
+            thread::spawn(move || {
+                allocated_socket.set_read_timeout(Some(Duration::from_millis(2000))).unwrap();
+
+                let mut buffer = [0u8; 512];
+                match allocated_socket.recv(&mut buffer) {
+                    Ok(number_of_bytes) => {
+                        let rpc = RPC::unmarshall(&buffer[..number_of_bytes]);
+                        match &rpc {
+                            RPC::Mount(call, Mount::Procedure::Export(export)) => {
+                                handler.on_event("Export", rpc);
+                            },
+                            _ => {},
+                        }
+                    },
+                    Err(error) => eprintln!("{:?}", error.to_string()),
+                }
+            });
+        };
+    }
+}
+
+fn convert_u16_to_two_u8s_be(integer: u16) -> Vec<u8> {
+    let mut res = vec![];
+    res.write_u16::<BigEndian>(integer).unwrap();
+    res
+}

--- a/src/rpc/test.rs
+++ b/src/rpc/test.rs
@@ -1,0 +1,155 @@
+use super::{
+    RPC,
+    Portmap,
+    Mount,
+    NFS,
+    RPCProgram,
+    RPCProcedure,
+    RPCCall,
+};
+
+fn set_rpc_version_2(buffer: &mut [u8]) {
+    buffer[11] = 0x02;
+}
+
+#[test]
+fn it_fails_marshalling_rpc_v1() {
+    let buffer = [0x00; 72];
+    assert_eq!(match RPC::unmarshall_message(&buffer) {
+        Ok((_, _)) => "success",
+        Err(err) => err,
+    }, "Only RPC Version 2 is supported");
+}
+
+#[test]
+fn it_can_marshalling_rpc_v2() {
+    let mut buffer = [0x00; 72];
+    set_rpc_version_2(&mut buffer);
+
+    assert_eq!(match RPC::unmarshall_message(&buffer) {
+        Ok((call, _)) => call.rpc_version,
+        Err(_) => [0x00; 4],
+    }, [0x00, 0x00, 0x00, 0x02]);
+}
+
+#[test]
+fn it_can_unmarshal_message_into_rpc_call() {
+    let mut buffer = [0x00; 76];
+    set_rpc_version_2(&mut buffer);
+
+    assert_eq!(match RPC::unmarshall_message(&buffer) {
+        Ok((_, parameters)) => parameters.len(),
+        Err(_) => 0,
+    }, 16);
+
+    // Verify that our RPC packages is exactly 60 bytes
+    let mut buffer = [0x00; 90];
+    set_rpc_version_2(&mut buffer);
+
+    assert_eq!(match RPC::unmarshall_message(&buffer) {
+        Ok((_, parameters)) => parameters.len(),
+        Err(_) => 0,
+    }, 30);
+}
+
+#[test]
+fn it_can_match_programs_and_procedures() {
+    // Portmap
+    let mut buffer = [0x00; 72];
+    set_rpc_version_2(&mut buffer);
+    buffer[13] = 0x01;
+    buffer[14] = 0x86;
+    buffer[15] = 0xa0;
+    buffer[23] = 0x03;
+
+    // Assert ergonomics
+    const ERRORED_CASE: (RPCProgram, RPCProcedure) = (
+        RPCProgram::Unknown,
+        RPCProcedure::Unknown
+    );
+
+    fn assert_unpacking(
+        expected: (RPCProgram, RPCProcedure),
+        buffer: &mut [u8]
+    ) {
+        assert_eq!(match RPC::unmarshall_message(buffer) {
+            Ok(res) => (res.0.program, res.0.procedure),
+            Err(_) => ERRORED_CASE,
+        }, expected);
+    }
+
+    assert_unpacking((RPCProgram::Portmap, RPCProcedure::Getport), &mut buffer);
+
+    buffer[15] = 0xa5;
+    buffer[23] = 0x05;
+    assert_unpacking((RPCProgram::Mount, RPCProcedure::Export), &mut buffer);
+
+    buffer[23] = 0x01;
+    assert_unpacking((RPCProgram::Mount, RPCProcedure::Mnt), &mut buffer);
+
+    // Test NFS program
+    buffer[15] = 0xa3;
+    buffer[23] = 0x04;
+    assert_unpacking((RPCProgram::NFS, RPCProcedure::Lookup), &mut buffer);
+
+    buffer[23] = 0x06;
+    assert_unpacking((RPCProgram::NFS, RPCProcedure::Read), &mut buffer);
+
+    buffer[23] = 0x01;
+    assert_unpacking((RPCProgram::NFS, RPCProcedure::Getattr), &mut buffer);
+
+    buffer[23] = 0xff;
+    assert_unpacking((RPCProgram::NFS, RPCProcedure::Unknown), &mut buffer);
+
+    // Test fallback
+    buffer[15] = 0xDD;
+    buffer[23] = 0xDD;
+    assert_unpacking((RPCProgram::Unknown, RPCProcedure::Unknown), &mut buffer);
+}
+
+#[test]
+fn it_will_fail_if_message_type_is_reply() {
+    let mut buffer = [0x00; 76];
+    buffer[7] = 0x01;
+
+    assert_eq!(RPC::unmarshall_message(&buffer), Err("Server received a reply"));
+}
+
+#[test]
+fn it_will_unmarshall_into_rpc_enum() {
+    let mut buffer = [0x00; 76];
+    set_rpc_version_2(&mut buffer);
+    buffer[13] = 0x01;
+    buffer[14] = 0x86;
+    buffer[15] = 0xa0;
+    buffer[23] = 0x03;
+
+    buffer[60] = 0x00;
+    buffer[61] = 0x01;
+    buffer[62] = 0x86;
+    buffer[63] = 0xa5;
+
+    buffer[72] = 0x00;
+    buffer[73] = 0x01;
+    buffer[74] = 0xa4;
+    buffer[75] = 0x37;
+
+    let program = RPC::unmarshall(&buffer);
+    assert_eq!(match program {
+        RPC::Portmap(_rpc_call, program) => {
+            match program {
+                Portmap::Program::Getport(procedure) => {
+                    match procedure {
+                        Portmap::Procedure::Mount(portmap) => {
+                            assert_eq!(portmap.port, [0x00, 0x01, 0xa4, 0x37]);
+                            true
+                        },
+                        _ => false,
+                    }
+                },
+                _ => false,
+            }
+        },
+        _ => false,
+    }, true);
+}


### PR DESCRIPTION
## Structure RPC

This PR started out with a small and dedicated thing to implement (be able to reply to a RPC Mount::Export procedure).

I found a couple of major issues with the old implementation (which I more or less was aware should happen when I first built it). But easier to start small and refactor if necessary then the other way around.

So this PR tries to bring ability to support multiple RPC Programs and be able to setup dedicated communication thread for each inquiry.

I guess there will be room for a lot of improvements here further down the road.

A note to possible further reviewers is that currently my only focus is to get things to work.
Suggestions for better implementations is very much welcome as long as you don't mention external crates. I try to learn as much as possible.

And to add to that, during this PR i have touched these toootally new areas for me
* Endianess (omg `<<` | `>>` : I had seen the syntax before but it was something I never thought of even trying to understand)
* Poolable values
* RPCisch, very non generic implementation